### PR TITLE
Update protobuf-conformance to v27.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -773,7 +773,7 @@
       "license": "MIT"
     },
     "packages/protobuf-conformance": {
-      "version": "27.1.0",
+      "version": "27.3.0",
       "license": "Apache-2.0",
       "bin": {
         "conformance_proto_eject": "conformance_proto_eject.cjs",

--- a/packages/protobuf-conformance/README.md
+++ b/packages/protobuf-conformance/README.md
@@ -1,7 +1,7 @@
 protobuf-conformance
 ====================
 
-This package provides the Protobuf conformance test runner `conformance_test_runner` <!-- inject: release.tag_name -->v27.1<!-- end -->.
+This package provides the Protobuf conformance test runner `conformance_test_runner` <!-- inject: release.tag_name -->v27.3<!-- end -->.
 
 ```shell script
 npm install --save-dev protobuf-conformance

--- a/packages/protobuf-conformance/include/google/protobuf/test_messages_edition2023.proto
+++ b/packages/protobuf-conformance/include/google/protobuf/test_messages_edition2023.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package protobuf_test_messages.editions;
 
+option features.message_encoding = DELIMITED;
 option java_package = "com.google.protobuf_test_messages.edition2023";
 option java_multiple_files = true;
 option objc_class_prefix = "Editions";
@@ -9,7 +10,8 @@ option objc_class_prefix = "Editions";
 message TestAllTypesEdition2023 {
   message NestedMessage {
     int32 a = 1;
-    TestAllTypesEdition2023 corecursive = 2;
+    TestAllTypesEdition2023 corecursive = 2
+        [features.message_encoding = LENGTH_PREFIXED];
   }
 
   enum NestedEnum {
@@ -36,8 +38,10 @@ message TestAllTypesEdition2023 {
   string optional_string = 14;
   bytes optional_bytes = 15;
 
-  NestedMessage optional_nested_message = 18;
-  ForeignMessageEdition2023 optional_foreign_message = 19;
+  NestedMessage optional_nested_message = 18
+      [features.message_encoding = LENGTH_PREFIXED];
+  ForeignMessageEdition2023 optional_foreign_message = 19
+      [features.message_encoding = LENGTH_PREFIXED];
 
   NestedEnum optional_nested_enum = 21;
   ForeignEnumEdition2023 optional_foreign_enum = 22;
@@ -45,7 +49,8 @@ message TestAllTypesEdition2023 {
   string optional_string_piece = 24 [ctype = STRING_PIECE];
   string optional_cord = 25 [ctype = CORD];
 
-  TestAllTypesEdition2023 recursive_message = 27;
+  TestAllTypesEdition2023 recursive_message = 27
+      [features.message_encoding = LENGTH_PREFIXED];
 
   // Repeated
   repeated int32 repeated_int32 = 31;
@@ -64,8 +69,10 @@ message TestAllTypesEdition2023 {
   repeated string repeated_string = 44;
   repeated bytes repeated_bytes = 45;
 
-  repeated NestedMessage repeated_nested_message = 48;
-  repeated ForeignMessageEdition2023 repeated_foreign_message = 49;
+  repeated NestedMessage repeated_nested_message = 48
+      [features.message_encoding = LENGTH_PREFIXED];
+  repeated ForeignMessageEdition2023 repeated_foreign_message = 49
+      [features.message_encoding = LENGTH_PREFIXED];
 
   repeated NestedEnum repeated_nested_enum = 51;
   repeated ForeignEnumEdition2023 repeated_foreign_enum = 52;
@@ -152,7 +159,8 @@ message TestAllTypesEdition2023 {
 
   oneof oneof_field {
     uint32 oneof_uint32 = 111;
-    NestedMessage oneof_nested_message = 112;
+    NestedMessage oneof_nested_message = 112
+        [features.message_encoding = LENGTH_PREFIXED];
     string oneof_string = 113;
     bytes oneof_bytes = 114;
     bool oneof_bool = 115;
@@ -170,8 +178,8 @@ message TestAllTypesEdition2023 {
     int32 group_int32 = 202;
     uint32 group_uint32 = 203;
   }
-  GroupLikeType groupliketype = 201 [features.message_encoding = DELIMITED];
-  GroupLikeType delimited_field = 202 [features.message_encoding = DELIMITED];
+  GroupLikeType groupliketype = 201;
+  GroupLikeType delimited_field = 202;
 }
 
 message ForeignMessageEdition2023 {
@@ -193,6 +201,6 @@ message GroupLikeType {
 }
 
 extend TestAllTypesEdition2023 {
-  GroupLikeType groupliketype = 121 [features.message_encoding = DELIMITED];
-  GroupLikeType delimited_ext = 122 [features.message_encoding = DELIMITED];
+  GroupLikeType groupliketype = 121;
+  GroupLikeType delimited_ext = 122;
 }

--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf-conformance",
-  "version": "27.1.0",
-  "upstreamVersion": "v27.1",
+  "version": "27.3.0",
+  "upstreamVersion": "v27.3",
   "bin": {
     "conformance_test_runner": "conformance_test_runner.cjs",
     "conformance_proto_eject": "conformance_proto_eject.cjs"


### PR DESCRIPTION
Update the package `protobuf-conformance` to the upstream release [v27.3](https://github.com/protocolbuffers/protobuf/releases/tag/v27.3).
Merging this PR will publish version 27.3.0 of the package.