### PR TITLE
Update protobuf-conformance to v32.0-rc2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -773,7 +773,7 @@
       "license": "MIT"
     },
     "packages/protobuf-conformance": {
-      "version": "32.0.0-rc1",
+      "version": "32.0.0-rc2",
       "license": "Apache-2.0",
       "bin": {
         "conformance_proto_eject": "conformance_proto_eject.cjs",

--- a/packages/protobuf-conformance/README.md
+++ b/packages/protobuf-conformance/README.md
@@ -1,7 +1,7 @@
 protobuf-conformance
 ====================
 
-This package provides the Protobuf conformance test runner `conformance_test_runner` <!-- inject: release.tag_name -->v32.0-rc1<!-- end -->.
+This package provides the Protobuf conformance test runner `conformance_test_runner` <!-- inject: release.tag_name -->v32.0-rc2<!-- end -->.
 
 ```shell script
 npm install --save-dev protobuf-conformance

--- a/packages/protobuf-conformance/package.json
+++ b/packages/protobuf-conformance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protobuf-conformance",
-  "version": "32.0.0-rc1",
-  "upstreamVersion": "v32.0-rc1",
+  "version": "32.0.0-rc2",
+  "upstreamVersion": "v32.0-rc2",
   "bin": {
     "conformance_test_runner": "conformance_test_runner.cjs",
     "conformance_proto_eject": "conformance_proto_eject.cjs"


### PR DESCRIPTION
Update the package `protobuf-conformance` to the upstream release [v32.0-rc2](https://github.com/protocolbuffers/protobuf/releases/tag/v32.0-rc2).
Merging this PR will publish version 32.0.0-rc2 of the package.