### PR TITLE
Update protoc to v34.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -724,7 +724,7 @@
       }
     },
     "packages/protoc": {
-      "version": "34.2.0",
+      "version": "34.2.1",
       "license": "Apache-2.0",
       "bin": {
         "protoc": "protoc.cjs"

--- a/packages/protoc/package.json
+++ b/packages/protoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protoc",
-  "version": "34.2.0",
+  "version": "34.2.1",
   "upstreamVersion": "v34.2",
   "description": "Installs the protocol buffer compiler \"protoc\" for you.",
   "bin": {


### PR DESCRIPTION
Update the package `protoc` to the upstream release [v34.2](https://github.com/protocolbuffers/protobuf/releases/tag/v34.2).
Merging this PR will tag a release, and publish version 34.2.1 of the package.